### PR TITLE
runtest.py: save the target_logs dir as well

### DIFF
--- a/runtest.py
+++ b/runtest.py
@@ -47,6 +47,14 @@ def preserve_artifacts(builddir, destdir, uid, removeimage=False):
     except IOError:
         pass
 
+    # also save the target logs (dmesg, X0.log...)
+    logsdir = "target_logs"
+    logsdir = os.path.join(builddir, logsdir)
+    try:
+        shutil.move(logsdir, destdir)
+    except IOError:
+        pass
+
     try:
         shutil.move(os.path.join(builddir, "test-stdout"), os.path.join(destdir, "test-stdout"))
     except IOError:


### PR DESCRIPTION
target_logs has the dmesg dump and a X0.log dump which we should also
save.

Signed-off-by: bavery brian.avery@intel.com
